### PR TITLE
Loosen the requirement for the CMake version

### DIFF
--- a/Clion_Code/CMakeLists.txt
+++ b/Clion_Code/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.15)
+cmake_minimum_required(VERSION 3.5)
 project(Clion_Code)
 
 set(CMAKE_CXX_STANDARD 14)


### PR DESCRIPTION
3.15 is not strictly needed; 3.5 works fine.